### PR TITLE
(#67) AbsolutePath: fix parent calculation code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- [#67: Unable to delete a file from a directory ending with dot](https://github.com/ForNeVeR/Vacuum/issues/67)
+
 ## [1.5.0] - 2021-12-12
 ### Changed
 - Slightly updated statistics output (less redundant information, less empty lines)

--- a/Vacuum.Tests/CleanTests.fs
+++ b/Vacuum.Tests/CleanTests.fs
@@ -44,6 +44,24 @@ let ``Cleaner should delete a file name ending with dot when forced``(): unit =
     Assert.Equal(Array.empty, directory.GetFiles())
 
 [<Fact>]
+let ``Cleaner is unable to delete a file from a directory ending with a dot without force mode``(): unit =
+    use directory = prepareEnvironment [|
+        Temp.CreateFile("ddd./test.txt")
+        Temp.CreateDirectory "ddd."
+    |]
+    let stats = Program.clean directory.Path (Temp.DefaultDateTime.AddDays(1.0)) None false
+    Assert.Equal(1, stats.States[Error])
+
+[<Fact>]
+let ``Cleaner deletes a file in a directory ending with a dot when forced``(): unit =
+    use directory = prepareEnvironment [|
+        Temp.CreateFile("ddd./test.txt")
+        Temp.CreateDirectory "ddd."
+    |]
+    let stats = Program.clean directory.Path (Temp.DefaultDateTime.AddDays(1.0)) None true
+    Assert.Equal(1, stats.States[ForceDeleted])
+
+[<Fact>]
 let ``Cleaner should be able to force-delete the directory trees with paths consisting of spaces``(): unit =
     use directory = prepareEnvironment [
         Temp.CreateFile(" / / /name.txt")

--- a/Vacuum.Tests/FileSystemTests.fs
+++ b/Vacuum.Tests/FileSystemTests.fs
@@ -38,6 +38,12 @@ let ``AbsolutePath.create throws for relative path``(): unit =
     ignore <| Assert.ThrowsAny<Exception>(fun () -> ignore <| AbsolutePath.create @"\disk relative path")
 
 [<Fact>]
+let ``/ operator normalizes the path string``(): unit =
+    let path = AbsolutePath.create @"C:\Temp\"
+    let relativePath = "foo/bar"
+    Assert.Equal(AbsolutePath.create @"C:\Temp\foo\bar", path / relativePath)
+
+[<Fact>]
 let ``AbsolutePath.EscapedPathString uses UNC for space-ending path``(): unit =
     let path = AbsolutePath.create @"C:\Temp\path "
     Assert.Equal(@"\\?\C:\Temp\path ", path.EscapedPathString)
@@ -46,6 +52,11 @@ let ``AbsolutePath.EscapedPathString uses UNC for space-ending path``(): unit =
 let ``AbsolutePath.EscapedPathString uses UNC for dot-ending path``(): unit =
     let path = AbsolutePath.create @"C:\Temp\path."
     Assert.Equal(@"\\?\C:\Temp\path.", path.EscapedPathString)
+
+[<Fact>]
+let ``AbsolutePath::EscapedPathString uses UNC prefix if parent directory ends with dot``(): unit =
+    let path = AbsolutePath.create @"C:\Temp\path.\foo.txt"
+    Assert.Equal(@"\\?\C:\Temp\path.\foo.txt", path.EscapedPathString)
 
 [<Fact>]
 let ``AbsolutePath.GetParent() should return a proper parent for a file in a space-ending directory``() =
@@ -58,6 +69,12 @@ let ``AbsolutePath.GetParent() should return a proper parent for multiple space-
     let path = AbsolutePath.create @"C:\Temp\ \ \"
     let parent = path.GetParent()
     Assert.Equal(AbsolutePath.create @"C:\Temp\ \", parent)
+
+[<Fact>]
+let ``AbsolutePath::GetParent preserves trailing dots``(): unit =
+    let path = AbsolutePath.create @"C:\Temp\aaa.\file.txt"
+    let parent = path.GetParent()
+    Assert.Equal(AbsolutePath.create @"C:\Temp\aaa.\", parent)
 
 [<Fact>]
 let ``AbsolutePath.FileName should return a space for a directory consisting of space``() =

--- a/Vacuum/AbsolutePath.fs
+++ b/Vacuum/AbsolutePath.fs
@@ -8,6 +8,15 @@ open System.Text.RegularExpressions
 type AbsolutePath = private AbsolutePath of string with
     static member UncPathPrefix = @"\\?\"
 
+    static member private normalizePathWithoutUncPrefix(p: string) =
+        let withNormalizedSeparators = p.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+        let withTrimmedSeparators = withNormalizedSeparators.TrimEnd Path.DirectorySeparatorChar
+        let withDeduplicatedSeparators = Regex.Replace(withTrimmedSeparators,
+                                                       $"{Regex.Escape(string Path.DirectorySeparatorChar)}+",
+                                                       string Path.DirectorySeparatorChar,
+                                                       RegexOptions.CultureInvariant)
+        withDeduplicatedSeparators
+
     /// Checks that the path represents an absolute path. For local Windows paths, it checks that the path is a path
     /// with disk letter and that it is rooted on that disk. Path.IsPathRooted won't work because it doesn't work for
     /// disk-relative paths such as "C:Temp".
@@ -23,21 +32,15 @@ type AbsolutePath = private AbsolutePath of string with
             if path.StartsWith(AbsolutePath.UncPathPrefix, StringComparison.Ordinal)
             then path.Substring AbsolutePath.UncPathPrefix.Length
             else path
-        let withNormalizedSeparators = withoutUncPrefix.Replace(Path.AltDirectorySeparatorChar,
-                                                    Path.DirectorySeparatorChar)
-        let withTrimmedSeparators = withNormalizedSeparators.TrimEnd Path.DirectorySeparatorChar
-        let withDeduplicatedSeparators = Regex.Replace(withTrimmedSeparators,
-                                                       sprintf "%s+" (Regex.Escape (string Path.DirectorySeparatorChar)),
-                                                       string Path.DirectorySeparatorChar,
-                                                       RegexOptions.CultureInvariant)
 
-        let result = AbsolutePath withDeduplicatedSeparators
+        let normalizedPath = AbsolutePath.normalizePathWithoutUncPrefix withoutUncPrefix
+        let result = AbsolutePath normalizedPath
         AbsolutePath.assertAbsolute result
         result
 
     static member (/) (p1: AbsolutePath, p2: string): AbsolutePath =
         let (AbsolutePath p1) = p1
-        let resultPath = Path.Combine(p1, p2)
+        let resultPath = Path.Combine(p1, AbsolutePath.normalizePathWithoutUncPrefix p2)
         AbsolutePath resultPath
 
     /// Returns the path string optionally prefixed by the UNC path prefix (\\?\) if necessary.
@@ -45,8 +48,11 @@ type AbsolutePath = private AbsolutePath of string with
     /// It may be necessary if the path ends with a space or a dot.
     member this.EscapedPathString: string =
         let (AbsolutePath p) = this
-        if p.EndsWith ' ' || p.EndsWith '.' then
-            sprintf @"\\?\%s" p
+        let isPrefixRequired =
+            p.Split Path.DirectorySeparatorChar
+            |> Array.exists (fun p -> p.EndsWith ' ' || p.EndsWith '.')
+        if isPrefixRequired then
+            AbsolutePath.UncPathPrefix + p
         else
             p
 
@@ -62,6 +68,9 @@ type AbsolutePath = private AbsolutePath of string with
 
     member this.GetParent(): AbsolutePath =
         let (AbsolutePath p) = this
-        let parentPath = Directory.GetParent(p).ToString() // called instead of FullPath, because FullPath eats trailing
-                                                           // spaces from the names
+        let lastSeparatorIndex = p.LastIndexOf Path.DirectorySeparatorChar
+        if lastSeparatorIndex = -1 then
+            failwithf $"No parent path could be determined for path \"{this.RawPathString}\"."
+
+        let parentPath = p.Substring(0, lastSeparatorIndex)
         AbsolutePath parentPath


### PR DESCRIPTION
Turns out that `Directory::GetParent` weren't always working properly.

Closes #67.