### PR TITLE
(#86) Commands: Support `g` suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Main command-line arguments:
   (which uses certain environment variables to determine the path).
 - `(-p|--period) <number>`: number of days for entry to be untouched before
   being deleted by Vacuum. 30 by default.
-- `(-s|--space) (<number>|<number>k|<number>m)` amount of space to clean up (`k`
-  = kibibytes, m = mebibytes). In space-cleaning mode, Vacuum will still clean
+- `(-s|--space) (<number>|<number>k|<number>m|<number>g)` amount of space to clean up (`k`
+  = kibibytes, m = mebibytes, g = gibibytes). In space-cleaning mode, Vacuum will still clean
   up the oldest items first.
 
   > **Pro Tip:**

--- a/Vacuum.Tests/CommandLineParserTests.fs
+++ b/Vacuum.Tests/CommandLineParserTests.fs
@@ -22,10 +22,13 @@ let ``--space parameter should be parsed with postfix`` () =
 
     let k = 1024L
     let M = k * 1024L
+    let G = M * 1024L
     test "10" 10L
     test "10k" (10L * k)
     test "10m" (10L * M)
     test "10M" (10L * M)
+    test "10g" (10L * G)
+    test "10G" (10L * G)
 
 [<Fact>]
 let ``--force parameter should be parsed``(): unit =

--- a/Vacuum/Commands.fs
+++ b/Vacuum/Commands.fs
@@ -20,7 +20,7 @@ type Clean =
         [<Option(
             's',
             "space",
-            HelpText = "Amount of space to be freed disregard the dates. Off by default. Supports k and m postfix. For example, 10k = 10 kibibytes, 10m = 10 mebibytes.")>]
+            HelpText = "Amount of space to be freed disregard the dates. Off by default. Supports k, m and g postfix. For example, 10k = 10 kibibytes, 10m = 10 mebibytes, 10g = 10 gibibytes.")>]
         Space: string option
 
         [<Option(
@@ -46,5 +46,6 @@ type Clean =
         match this.Space with
         | Some space when space.ToLowerInvariant().EndsWith("k") -> Some (1024L * (int64 <| allButLast space))
         | Some space when space.ToLowerInvariant().EndsWith("m") -> Some (1024L * 1024L * (int64 <| allButLast space))
+        | Some space when space.ToLowerInvariant().EndsWith("g") -> Some (1024L * 1024L * 1024L * (int64 <| allButLast space))
         | Some space -> Some (int64 space)
         | None -> None


### PR DESCRIPTION
This closes #86 by adding the ability to use a `g` suffix for Gibiytes.